### PR TITLE
Silence the spam

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,35 +151,35 @@ class datadog_agent (
 
   # Set initial permissions on log files
   exec { 'messages_permissions':
-    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/messages || true',
-    unless  => 'if [ -f /var/log/messages ] ; then if [ `getfacl /var/log/messages 2>/dev/null | sed -n -e 6p` == "group:dd-agent:r-x" ] ; then true ; else false ; fi ; fi',
+    command  => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/messages || true',
+    unless   => 'if [ -f /var/log/messages ] ; then if [ `getfacl /var/log/messages 2>/dev/null | sed -n -e 6p` != "group:dd-agent:r-x" ] ; then false ; fi ; fi',
     provider => shell;
   }
   exec { 'secure_permissions':
-    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/secure || true',
-    unless  => 'if [ -f /var/log/secure ] ; then if [ `getfacl /var/log/secure 2>/dev/null | sed -n -e 6p` == "group:dd-agent:r-x" ] ; then true ; else false ; fi ; fi',
+    command  => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/secure || true',
+    unless   => 'if [ -f /var/log/secure ] ; then if [ `getfacl /var/log/secure 2>/dev/null | sed -n -e 6p` != "group:dd-agent:r-x" ] ; then false ; fi ; fi',
     provider => shell;
   }
   exec { 'uwsgi_permissions':
-    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi.log || true',
-    unless  => 'if [ -f /var/log/adroll/uwsgi.log ] ; then if [ `getfacl /var/log/adroll/uwsgi.log 2>/dev/null | sed -n -e 6p` == "group:dd-agent:r-x" ] ; then true ; else false ; fi ; fi',
+    command  => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi.log || true',
+    unless   => 'if [ -f /var/log/adroll/uwsgi.log ] ; then if [ `getfacl /var/log/adroll/uwsgi.log 2>/dev/null | sed -n -e 6p` != "group:dd-agent:r-x" ] ; then false ; fi ; fi',
     provider => shell;
   }
   exec { 'uwsgi-gk_permissions':
-    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-gk.log || true',
-    onlyif  => 'if [ -f /var/log/adroll/uwsgi-gk.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-gk.log 2>/dev/null | sed -n -e 6p` == "group:dd-agent:r-x" ] ; then true ; else false ; fi ; fi',
+    command  => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-gk.log || true',
+    unless   => 'if [ -f /var/log/adroll/uwsgi-gk.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-gk.log 2>/dev/null | sed -n -e 6p` != "group:dd-agent:r-x" ] ; then false ; fi ; fi',
     provider => shell;
   }
   exec { 'uwsgi-report_permissions':
-    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-report.log || true',
-    unless  => 'if [ -f /var/log/adroll/uwsgi-report.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-report.log 2>/dev/null | sed -n -e 6p` == "group:dd-agent:r-x" ] ; then true ; else false ; fi ; fi',
+    command  => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-report.log || true',
+    unless   => 'if [ -f /var/log/adroll/uwsgi-report.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-report.log 2>/dev/null | sed -n -e 6p` != "group:dd-agent:r-x" ] ; then false ; fi ; fi',
     provider => shell;
   }
 
   # Sometimes the Datadog auth_token file becomes owned by root, chown it just in case
   exec { 'chown_auth_token':
     command => 'chown dd-agent /etc/datadog-agent/auth_token || true',
-    unless  => 'if [ `stat -c %U  /etc/datadog-agent/auth_token` == "dd-agent" ] ; then true ; else false; fi',
+    unless  => 'if [ `stat -c %U  /etc/datadog-agent/auth_token` != "dd-agent" ] ; then false; fi',
     provider => shell,
     notify  => Service[$service_name];
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,24 +151,30 @@ class datadog_agent (
 
   # Set initial permissions on log files
   exec { 'messages_permissions':
-    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/messages || true';
+    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/messages || true',
+    onlyif  => 'if [ -f /var/log/messages ] ; then if [ `getfacl /var/log/messages 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi';
   }
   exec { 'secure_permissions':
-    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/secure || true';
+    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/secure || true',
+    onlyif  => 'if [ -f /var/log/secure ] ; then if [ `getfacl /var/log/secure 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi';
   }
   exec { 'uwsgi_permissions':
-    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi.log || true';
+    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi.log || true',
+    onlyif  => 'if [ -f /var/log/adroll/uwsgi.log ] ; then if [ `getfacl /var/log/adroll/uwsgi.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi';
   }
   exec { 'uwsgi-gk_permissions':
-    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-gk.log || true';
+    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-gk.log || true',
+    onlyif  => 'if [ -f /var/log/adroll/uwsgi-gk.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-gk.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi';
   }
   exec { 'uwsgi-report_permissions':
-    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-report.log || true';
+    command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-report.log || true',
+    onlyif  => 'if [ -f /var/log/adroll/uwsgi-report.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-report.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi';
   }
 
   # Sometimes the Datadog auth_token file becomes owned by root, chown it just in case
   exec { 'chown_auth_token':
     command => 'chown dd-agent /etc/datadog-agent/auth_token || true',
+    onlyif  => 'if [ `stat -c %U  /etc/datadog-agent/auth_token` == "dd-agent" ] ; then false ; fi',
     notify  => Service[$service_name];
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,29 +152,35 @@ class datadog_agent (
   # Set initial permissions on log files
   exec { 'messages_permissions':
     command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/messages || true',
-    onlyif  => 'if [ -f /var/log/messages ] ; then if [ `getfacl /var/log/messages 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi';
+    onlyif  => 'if [ -f /var/log/messages ] ; then if [ `getfacl /var/log/messages 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi',
+    provider => shell;
   }
   exec { 'secure_permissions':
     command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/secure || true',
-    onlyif  => 'if [ -f /var/log/secure ] ; then if [ `getfacl /var/log/secure 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi';
+    onlyif  => 'if [ -f /var/log/secure ] ; then if [ `getfacl /var/log/secure 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi',
+    provider => shell;
   }
   exec { 'uwsgi_permissions':
     command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi.log || true',
-    onlyif  => 'if [ -f /var/log/adroll/uwsgi.log ] ; then if [ `getfacl /var/log/adroll/uwsgi.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi';
+    onlyif  => 'if [ -f /var/log/adroll/uwsgi.log ] ; then if [ `getfacl /var/log/adroll/uwsgi.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi',
+    provider => shell;
   }
   exec { 'uwsgi-gk_permissions':
     command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-gk.log || true',
-    onlyif  => 'if [ -f /var/log/adroll/uwsgi-gk.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-gk.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi';
+    onlyif  => 'if [ -f /var/log/adroll/uwsgi-gk.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-gk.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi',
+    provider => shell;
   }
   exec { 'uwsgi-report_permissions':
     command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-report.log || true',
-    onlyif  => 'if [ -f /var/log/adroll/uwsgi-report.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-report.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi';
+    onlyif  => 'if [ -f /var/log/adroll/uwsgi-report.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-report.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi',
+    provider => shell;
   }
 
   # Sometimes the Datadog auth_token file becomes owned by root, chown it just in case
   exec { 'chown_auth_token':
     command => 'chown dd-agent /etc/datadog-agent/auth_token || true',
     onlyif  => 'if [ `stat -c %U  /etc/datadog-agent/auth_token` == "dd-agent" ] ; then false ; fi',
+    provider => shell,
     notify  => Service[$service_name];
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,34 +152,34 @@ class datadog_agent (
   # Set initial permissions on log files
   exec { 'messages_permissions':
     command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/messages || true',
-    onlyif  => 'if [ -f /var/log/messages ] ; then if [ `getfacl /var/log/messages 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi',
+    unless  => 'if [ -f /var/log/messages ] ; then if [ `getfacl /var/log/messages 2>/dev/null | sed -n -e 6p` == "group:dd-agent:r-x" ] ; then true ; else false ; fi ; fi',
     provider => shell;
   }
   exec { 'secure_permissions':
     command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/secure || true',
-    onlyif  => 'if [ -f /var/log/secure ] ; then if [ `getfacl /var/log/secure 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi',
+    unless  => 'if [ -f /var/log/secure ] ; then if [ `getfacl /var/log/secure 2>/dev/null | sed -n -e 6p` == "group:dd-agent:r-x" ] ; then true ; else false ; fi ; fi',
     provider => shell;
   }
   exec { 'uwsgi_permissions':
     command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi.log || true',
-    onlyif  => 'if [ -f /var/log/adroll/uwsgi.log ] ; then if [ `getfacl /var/log/adroll/uwsgi.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi',
+    unless  => 'if [ -f /var/log/adroll/uwsgi.log ] ; then if [ `getfacl /var/log/adroll/uwsgi.log 2>/dev/null | sed -n -e 6p` == "group:dd-agent:r-x" ] ; then true ; else false ; fi ; fi',
     provider => shell;
   }
   exec { 'uwsgi-gk_permissions':
     command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-gk.log || true',
-    onlyif  => 'if [ -f /var/log/adroll/uwsgi-gk.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-gk.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi',
+    onlyif  => 'if [ -f /var/log/adroll/uwsgi-gk.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-gk.log 2>/dev/null | sed -n -e 6p` == "group:dd-agent:r-x" ] ; then true ; else false ; fi ; fi',
     provider => shell;
   }
   exec { 'uwsgi-report_permissions':
     command => '/usr/bin/setfacl -m g:dd-agent:rx /var/log/adroll/uwsgi-report.log || true',
-    onlyif  => 'if [ -f /var/log/adroll/uwsgi-report.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-report.log 2>/dev/null | sed -n -e 6p` == "ggroup:dd-agent:r-x" ] ; then false ; fi ; fi',
+    unless  => 'if [ -f /var/log/adroll/uwsgi-report.log ] ; then if [ `getfacl /var/log/adroll/uwsgi-report.log 2>/dev/null | sed -n -e 6p` == "group:dd-agent:r-x" ] ; then true ; else false ; fi ; fi',
     provider => shell;
   }
 
   # Sometimes the Datadog auth_token file becomes owned by root, chown it just in case
   exec { 'chown_auth_token':
     command => 'chown dd-agent /etc/datadog-agent/auth_token || true',
-    onlyif  => 'if [ `stat -c %U  /etc/datadog-agent/auth_token` == "dd-agent" ] ; then false ; fi',
+    unless  => 'if [ `stat -c %U  /etc/datadog-agent/auth_token` == "dd-agent" ] ; then true ; else false; fi',
     provider => shell,
     notify  => Service[$service_name];
   }


### PR DESCRIPTION
This will eliminate the following on every puppet run:
```
Notice: /Stage[main]/Datadog_agent/Exec[uwsgi-gk_permissions]/returns: executed successfully
Notice: /Stage[main]/Datadog_agent/Exec[secure_permissions]/returns: executed successfully
Notice: /Stage[main]/Datadog_agent/Exec[uwsgi_permissions]/returns: executed successfully
Notice: /Stage[main]/Datadog_agent/Exec[messages_permissions]/returns: executed successfully
Notice: /Stage[main]/Datadog_agent/Exec[chown_auth_token]/returns: executed successfully
Info: /Stage[main]/Datadog_agent/Exec[chown_auth_token]: Scheduling refresh of Service[datadog-agent]
Notice: /Stage[main]/Datadog_agent/Exec[uwsgi-report_permissions]/returns: executed successfully
Notice: /Stage[main]/Datadog_agent/Service[datadog-agent]: Triggered 'refresh' from 1 events
```
